### PR TITLE
Websocket depth Updated, added utilities and version changed from 1.0.43 to 1.0.44

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="openalgo",
-    version="1.0.43",
+    version="1.0.44",
     author="Rajandran R",
     author_email="rajandran@marketcalls.in",
     description="A Python library for interacting with OpenAlgo's trading APIs and Technical Indicators",

--- a/LICENSE
+++ b/LICENSE
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="openalgo",
-    version="1.0.44",
+    version="1.0.45",
     author="Rajandran R",
     author_email="rajandran@marketcalls.in",
     description="A Python library for interacting with OpenAlgo's trading APIs and Technical Indicators",

--- a/PKG-INFO
+++ b/PKG-INFO
@@ -1,6 +1,6 @@
 Metadata-Version: 2.4
 Name: openalgo
-Version: 1.0.43
+Version: 1.0.44
 Summary: A Python library for interacting with OpenAlgo's trading APIs with high-performance technical indicators
 Home-page: https://openalgo.in
 Author: Rajandran R

--- a/PKG-INFO
+++ b/PKG-INFO
@@ -1,6 +1,6 @@
 Metadata-Version: 2.4
 Name: openalgo
-Version: 1.0.44
+Version: 1.0.45
 Summary: A Python library for interacting with OpenAlgo's trading APIs with high-performance technical indicators
 Home-page: https://openalgo.in
 Author: Rajandran R

--- a/openalgo/__init__.py
+++ b/openalgo/__init__.py
@@ -11,6 +11,7 @@ from .strategy import Strategy
 from .feed import FeedAPI
 from .options import OptionsAPI
 from .telegram import TelegramAPI
+from .utilities import UtilitiesAPI
 from .indicators import ta
 
 # ------------------------------------------------------------------
@@ -26,7 +27,7 @@ _nb.jit = _jit_shim  # monkey-patch once at import time
 nbjit = _jit_shim
 prange = _prange
 
-class api(OrderAPI, DataAPI, AccountAPI, FeedAPI, OptionsAPI, TelegramAPI):
+class api(OrderAPI, DataAPI, AccountAPI, FeedAPI, OptionsAPI, TelegramAPI, UtilitiesAPI):
     """
     OpenAlgo API client class
     """

--- a/openalgo/__init__.py
+++ b/openalgo/__init__.py
@@ -87,7 +87,7 @@ class api(OrderAPI, DataAPI, AccountAPI, FeedAPI, OptionsAPI, TelegramAPI, Utili
         self.quotes_callback = None
         self.depth_callback = None
 
-__version__ = "1.0.43"
+__version__ = "1.0.44"
 
 # Export main components for easy access
 __all__ = ['api', 'Strategy', 'ta', 'nbjit', 'prange']

--- a/openalgo/__init__.py
+++ b/openalgo/__init__.py
@@ -87,7 +87,7 @@ class api(OrderAPI, DataAPI, AccountAPI, FeedAPI, OptionsAPI, TelegramAPI, Utili
         self.quotes_callback = None
         self.depth_callback = None
 
-__version__ = "1.0.44"
+__version__ = "1.0.45"
 
 # Export main components for easy access
 __all__ = ['api', 'Strategy', 'ta', 'nbjit', 'prange']

--- a/openalgo/feed.py
+++ b/openalgo/feed.py
@@ -871,9 +871,9 @@ class FeedAPI(BaseAPI):
                     for i, level in enumerate(buy_depth):
                         level_num = str(i + 1)
                         result["depth"][ex][sym]["buyBook"][level_num] = {
-                            "price": float(level.get('price', 0)),
-                            "qty": int(level.get('quantity', 0)),
-                            "orders": int(level.get('orders', 0))
+                            "price": float(level.get('price') or 0),
+                            "qty": int(level.get('quantity') or 0),
+                            "orders": int(level.get('orders') or 0)
                         }
 
                     # If there are fewer than 5 levels, add empty levels to complete the structure
@@ -890,9 +890,9 @@ class FeedAPI(BaseAPI):
                     for i, level in enumerate(sell_depth):
                         level_num = str(i + 1)
                         result["depth"][ex][sym]["sellBook"][level_num] = {
-                            "price": float(level.get('price', 0)),
-                            "qty": int(level.get('quantity', 0)),
-                            "orders": int(level.get('orders', 0))
+                            "price": float(level.get('price') or 0),
+                            "qty": int(level.get('quantity') or 0),
+                            "orders": int(level.get('orders') or 0)
                         }
 
                     # If there are fewer than 5 levels, add empty levels to complete the structure

--- a/openalgo/feed.py
+++ b/openalgo/feed.py
@@ -871,37 +871,37 @@ class FeedAPI(BaseAPI):
                     for i, level in enumerate(buy_depth):
                         level_num = str(i + 1)
                         result["depth"][ex][sym]["buyBook"][level_num] = {
-                            "price": str(level.get('price', 0)),
-                            "qty": str(level.get('quantity', 0)),
-                            "orders": str(level.get('orders', 0))
+                            "price": float(level.get('price', 0)),
+                            "qty": int(level.get('quantity', 0)),
+                            "orders": int(level.get('orders', 0))
                         }
-                    
+
                     # If there are fewer than 5 levels, add empty levels to complete the structure
                     for i in range(len(buy_depth), 5):
                         level_num = str(i + 1)
                         result["depth"][ex][sym]["buyBook"][level_num] = {
-                            "price": "0",
-                            "qty": "0",
-                            "orders": "0"
+                            "price": 0.0,
+                            "qty": 0,
+                            "orders": 0
                         }
-                    
+
                     # Process sell depth book
                     sell_depth = data.get('depth', {}).get('sell', [])
                     for i, level in enumerate(sell_depth):
                         level_num = str(i + 1)
                         result["depth"][ex][sym]["sellBook"][level_num] = {
-                            "price": str(level.get('price', 0)),
-                            "qty": str(level.get('quantity', 0)),
-                            "orders": str(level.get('orders', 0))
+                            "price": float(level.get('price', 0)),
+                            "qty": int(level.get('quantity', 0)),
+                            "orders": int(level.get('orders', 0))
                         }
-                    
+
                     # If there are fewer than 5 levels, add empty levels to complete the structure
                     for i in range(len(sell_depth), 5):
                         level_num = str(i + 1)
                         result["depth"][ex][sym]["sellBook"][level_num] = {
-                            "price": "0",
-                            "qty": "0",
-                            "orders": "0"
+                            "price": 0.0,
+                            "qty": 0,
+                            "orders": 0
                         }
             
             return result

--- a/openalgo/feed.py
+++ b/openalgo/feed.py
@@ -274,6 +274,10 @@ class FeedAPI(BaseAPI):
                                 'close': market_data.get("close", 0),
                                 'ltp': market_data.get("ltp", 0),
                                 'volume': market_data.get("volume", 0),
+                                'last_trade_quantity': market_data.get("last_trade_quantity", 0),
+                                'avg_trade_price': market_data.get("avg_trade_price", 0),
+                                'change': market_data.get("change", 0),
+                                'change_percent': market_data.get("change_percent", 0),
                                 'timestamp': market_data.get("timestamp", int(time.time() * 1000))
                             }
                             
@@ -771,7 +775,11 @@ class FeedAPI(BaseAPI):
                     "low": low,
                     "close": close,
                     "ltp": ltp,
-                    "volume": volume
+                    "volume": volume,
+                    "last_trade_quantity": last_trade_quantity,
+                    "avg_trade_price": avg_trade_price,
+                    "change": change,
+                    "change_percent": change_percent
                 }}}}
         """
         with self.lock:
@@ -806,7 +814,11 @@ class FeedAPI(BaseAPI):
                         "low": data['low'],
                         "close": data['close'],
                         "ltp": data['ltp'],
-                        "volume": data.get('volume', 0)
+                        "volume": data.get('volume', 0),
+                        "last_trade_quantity": data.get('last_trade_quantity', 0),
+                        "avg_trade_price": data.get('avg_trade_price', 0),
+                        "change": data.get('change', 0),
+                        "change_percent": data.get('change_percent', 0)
                     }
             
             return result

--- a/openalgo/utilities.py
+++ b/openalgo/utilities.py
@@ -1,0 +1,165 @@
+# -*- coding: utf-8 -*-
+"""
+OpenAlgo REST API Documentation - Utilities Methods
+    https://docs.openalgo.in
+"""
+
+import httpx
+from datetime import datetime
+from .base import BaseAPI
+
+
+class UtilitiesAPI(BaseAPI):
+    """
+    Utilities API methods for OpenAlgo.
+    Inherits from the BaseAPI class.
+    """
+
+    def _make_request(self, endpoint, payload):
+        """Make HTTP request with proper error handling"""
+        url = self.base_url + endpoint
+        try:
+            response = httpx.post(url, json=payload, headers=self.headers, timeout=self.timeout)
+            return self._handle_response(response)
+        except httpx.TimeoutException:
+            return {
+                'status': 'error',
+                'message': 'Request timed out. The server took too long to respond.',
+                'error_type': 'timeout_error'
+            }
+        except httpx.ConnectError:
+            return {
+                'status': 'error',
+                'message': 'Failed to connect to the server. Please check if the server is running.',
+                'error_type': 'connection_error'
+            }
+        except httpx.HTTPError as e:
+            return {
+                'status': 'error',
+                'message': f'HTTP error occurred: {str(e)}',
+                'error_type': 'http_error'
+            }
+        except Exception as e:
+            return {
+                'status': 'error',
+                'message': f'An unexpected error occurred: {str(e)}',
+                'error_type': 'unknown_error'
+            }
+
+    def _handle_response(self, response):
+        """Helper method to handle API responses"""
+        try:
+            if response.status_code != 200:
+                return {
+                    'status': 'error',
+                    'message': f'HTTP {response.status_code}: {response.text}',
+                    'code': response.status_code,
+                    'error_type': 'http_error'
+                }
+
+            data = response.json()
+            if data.get('status') == 'error':
+                return {
+                    'status': 'error',
+                    'message': data.get('message', 'Unknown error'),
+                    'code': response.status_code,
+                    'error_type': 'api_error'
+                }
+            return data
+
+        except ValueError:
+            return {
+                'status': 'error',
+                'message': 'Invalid JSON response from server',
+                'raw_response': response.text,
+                'error_type': 'json_error'
+            }
+        except Exception as e:
+            return {
+                'status': 'error',
+                'message': f'Error processing response: {str(e)}',
+                'error_type': 'unknown_error'
+            }
+
+    def holidays(self, year=None):
+        """
+        Get market holidays for a specific year.
+
+        Args:
+            year (int, optional): Year for holiday data (2020-2050).
+                                  Defaults to current year if not provided.
+
+        Returns:
+            dict: Response containing holiday data with the following structure:
+                {
+                    "status": "success",
+                    "year": 2025,
+                    "timezone": "Asia/Kolkata",
+                    "data": [
+                        {
+                            "date": "2025-02-26",
+                            "description": "Maha Shivaratri",
+                            "holiday_type": "TRADING_HOLIDAY",
+                            "closed_exchanges": ["NSE", "BSE", "NFO", "BFO", "CDS", "BCD"],
+                            "open_exchanges": [
+                                {
+                                    "exchange": "MCX",
+                                    "start_time": 1740549000000,
+                                    "end_time": 1740602700000
+                                }
+                            ]
+                        }
+                    ]
+                }
+        """
+        payload = {
+            "apikey": self.api_key
+        }
+
+        if year is not None:
+            payload["year"] = year
+
+        return self._make_request("market/holidays", payload)
+
+    def timings(self, date=None):
+        """
+        Get market timings for a specific date.
+
+        Args:
+            date (str, optional): Date in YYYY-MM-DD format.
+                                  Defaults to current date if not provided.
+
+        Returns:
+            dict: Response containing market timing data with the following structure:
+                {
+                    "status": "success",
+                    "data": [
+                        {
+                            "exchange": "NSE",
+                            "start_time": 1745984700000,
+                            "end_time": 1746007200000
+                        },
+                        {
+                            "exchange": "BSE",
+                            "start_time": 1745984700000,
+                            "end_time": 1746007200000
+                        },
+                        {
+                            "exchange": "MCX",
+                            "start_time": 1745983800000,
+                            "end_time": 1746037500000
+                        }
+                    ]
+                }
+
+                Note: Empty data array indicates market is closed (holiday).
+        """
+        if date is None:
+            date = datetime.now().strftime("%Y-%m-%d")
+
+        payload = {
+            "apikey": self.api_key,
+            "date": date
+        }
+
+        return self._make_request("market/timings", payload)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="openalgo",
-    version="1.0.43",
+    version="1.0.44",
     author="Rajandran R",
     author_email="rajandran@openalgo.in",
     description="A Python library for interacting with OpenAlgo's trading APIs with high-performance technical indicators",

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="openalgo",
-    version="1.0.44",
+    version="1.0.45",
     author="Rajandran R",
     author_email="rajandran@openalgo.in",
     description="A Python library for interacting with OpenAlgo's trading APIs with high-performance technical indicators",


### PR DESCRIPTION
Websocket depth Updated, added utilities and version changed from 1.0.43 to 1.0.44





<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalized websocket depth data types and added a Utilities API for holidays and market timings. Quotes now include last trade quantity, average trade price, change, and change_percent; version bumped to 1.0.45.

- **New Features**
  - UtilitiesAPI with holidays(year) and timings(date) endpoints, with error handling.
  - Exposed UtilitiesAPI on the main api client.
  - Expanded quotes payload: last_trade_quantity, avg_trade_price, change, change_percent.

- **Bug Fixes**
  - get_depth returns numeric types (price=float, qty=int, orders=int); missing levels padded with zeros.

<sup>Written for commit a9627d5e493ed2a21d726f4c05484499a4ef85f6. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





