### PR TITLE
fix(feed): add ping_interval/ping_timeout to prevent zombie WebSocket

### DIFF
--- a/openalgo/feed.py
+++ b/openalgo/feed.py
@@ -125,8 +125,16 @@ class FeedAPI(BaseAPI):
                 on_close=on_close
             )
             
-            # Start WebSocket connection in a separate thread
-            self.ws_thread = threading.Thread(target=self.ws.run_forever)
+            # Start WebSocket connection in a separate thread.
+            # ping_interval sends a WebSocket ping every 20s so the OS-level TCP
+            # connection cannot become a silent "zombie" (broker stops streaming
+            # ticks but the socket appears OPEN with no error). ping_timeout
+            # closes and triggers on_close if the pong is not received within
+            # 10s, allowing the caller to detect and reconnect.
+            self.ws_thread = threading.Thread(
+                target=self.ws.run_forever,
+                kwargs={"ping_interval": 20, "ping_timeout": 10},
+            )
             self.ws_thread.daemon = True
             self.ws_thread.start()
             


### PR DESCRIPTION
Without ping_interval, run_forever() never sends WebSocket pings. On unreliable connections (e.g. India VPS), the TCP socket can appear OPEN at the OS level while the broker has silently stopped streaming ticks. This is the "zombie WebSocket" problem: the client never sees an error or disconnect, so on_close never fires and reconnect logic never runs.

Setting ping_interval=20 causes websocket-client to send a ping frame every 20 seconds. If the pong is not received within ping_timeout=10s, the library closes the socket and fires on_close, allowing callers to detect the drop and reconnect.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add WebSocket keepalive to prevent zombie connections. We now run `websocket-client` with ping_interval=20 and ping_timeout=10, which sends a ping every 20s and closes if no pong in 10s so on_close fires and reconnect logic runs.

<sup>Written for commit 9ee86a73dc0588ed0910dbd811ef2ae51bf26388. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

